### PR TITLE
Redo implementation of float/double union handling

### DIFF
--- a/fastavro/__init__.py
+++ b/fastavro/__init__.py
@@ -40,7 +40,7 @@ Example usage::
         writer(out, schema, records)
 '''
 
-__version_info__ = (0, 23, 5)
+__version_info__ = (0, 23, 6)
 __version__ = '%s.%s.%s' % __version_info__
 
 

--- a/fastavro/_schema.pyx
+++ b/fastavro/_schema.pyx
@@ -67,37 +67,14 @@ def parse_schema(schema, expand=False, _write_hint=True, _force=False):
         return _parse_schema(schema, "", expand, _write_hint, set())
 
 
-cdef _reorder_float_unions(schema):
-    """Re-orders union types containing both "float" and "double",
-    so that "double" is preferred and no precision is lost when writing
-    64 bit python floats to ["float", "double"] union types
-    """
-
-    left = []
-    right = []
-
-    for sub in schema:
-        if sub == "float" or (hasattr(sub, "get") and sub.get("type") == "float"):
-            right.append(sub)
-        elif sub == "double" or (hasattr(sub, "get") and sub.get("type") == "double"):
-            left.append(sub)
-        else:
-            if len(right) == 0:
-                left.append(sub)
-            else:
-                right.append(sub)
-
-    return left + right
-
-
 cdef _parse_schema(schema, namespace, expand, _write_hint, named_schemas):
     # union schemas
     if isinstance(schema, list):
-        return _reorder_float_unions([
+        return [
             _parse_schema(
                 s, namespace, expand, False, named_schemas
             ) for s in schema
-        ])
+        ]
 
     # string schemas; this could be either a named schema or a primitive type
     elif not isinstance(schema, dict):

--- a/fastavro/_schema_py.py
+++ b/fastavro/_schema_py.py
@@ -194,39 +194,14 @@ def parse_schema(schema, expand=False, _write_hint=True, _force=False):
         return _parse_schema(schema, "", expand, _write_hint, set())
 
 
-def _reorder_float_unions(schema):
-    """Re-orders union types containing both "float" and "double",
-    so that "double" is preferred and no precision is lost when writing
-    64 bit python floats to ["float", "double"] union types.
-    """
-
-    left = []
-    right = []
-
-    for sub in schema:
-        if (sub == "float" or
-           (hasattr(sub, "get") and sub.get("type") == "float")):
-            right.append(sub)
-        elif (sub == "double" or
-              (hasattr(sub, "get") and sub.get("type") == "double")):
-            left.append(sub)
-        else:
-            if len(right) == 0:
-                left.append(sub)
-            else:
-                right.append(sub)
-
-    return left + right
-
-
 def _parse_schema(schema, namespace, expand, _write_hint, named_schemas):
     # union schemas
     if isinstance(schema, list):
-        return _reorder_float_unions([
+        return [
             _parse_schema(
                 s, namespace, expand, False, named_schemas
             ) for s in schema
-        ])
+        ]
 
     # string schemas; this could be either a named schema or a primitive type
     elif not isinstance(schema, dict):

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -230,9 +230,13 @@ cdef write_union(bytearray fo, datum, schema):
         pytype = type(datum)
         best_match_index = -1
         most_fields = -1
+        expect_double = False
         for index, candidate in enumerate(schema):
+            candidate_record_type = extract_record_type(candidate)
+            if expect_double and candidate_record_type != 'double':
+                continue
             if _validate(datum, candidate, raise_errors=False):
-                if extract_record_type(candidate) == 'record':
+                if candidate_record_type == 'record':
                     candidate_fields = set(
                         f["name"] for f in candidate["fields"]
                     )
@@ -244,8 +248,10 @@ cdef write_union(bytearray fo, datum, schema):
                 else:
                     best_match_index = index
                     # float conversions are lossy, so we keep
-                    # looking for another type if possible
-                    if candidate != 'float':
+                    # looking for a double if possible
+                    if candidate_record_type == 'float':
+                        expect_double = True
+                    else:
                         break
         if best_match_index < 0:
             msg = '%r (type %s) do not match %s' % (datum, pytype, schema)

--- a/fastavro/_write.pyx
+++ b/fastavro/_write.pyx
@@ -243,7 +243,10 @@ cdef write_union(bytearray fo, datum, schema):
                         most_fields = fields
                 else:
                     best_match_index = index
-                    break
+                    # float conversions are lossy, so we keep
+                    # looking for another type if possible
+                    if candidate != 'float':
+                        break
         if best_match_index < 0:
             msg = '%r (type %s) do not match %s' % (datum, pytype, schema)
             raise ValueError(msg)

--- a/fastavro/_write_py.py
+++ b/fastavro/_write_py.py
@@ -163,7 +163,10 @@ def write_union(encoder, datum, schema):
                         most_fields = fields
                 else:
                     best_match_index = index
-                    break
+                    # float conversions are lossy, so we keep
+                    # looking for another type if possible
+                    if candidate != 'float':
+                        break
         if best_match_index < 0:
             msg = '%r (type %s) do not match %s' % (datum, pytype, schema)
             raise ValueError(msg)

--- a/tests/test_complex.py
+++ b/tests/test_complex.py
@@ -61,8 +61,18 @@ schema = {
                     }
                 ]
             }
-                     }
-        }
+            }
+        }, {
+            "name": "array_of_unions_with_floats",
+            "type": ["null", {"type": "array",
+                              "items": [
+                                  "long",
+                                  "int",
+                                  "float",
+                                  "double",
+                              ]
+                              }]
+        },
     ],
     "namespace": "namespace",
     "name": "name",
@@ -128,3 +138,18 @@ def test_array_from_tuple():
     data_list = serialize({"type": "array", "items": "int"}, [1, 2, 3])
     data_tuple = serialize({"type": "array", "items": "int"}, (1, 2, 3))
     assert data_list == data_tuple
+
+
+def test_complex_schema_unions_with_floats():
+    data1 = {
+        'array_string': [],
+        'array_record': [],
+        'array_of_unions_with_floats': [1, 2, 3.14159265358979323846],
+    }
+    binary = serialize(schema, data1)
+    data2 = deserialize(schema, binary)
+    data1_compare = data1
+    data1_compare.update(
+        {'multi_union_time': None, 'array_bytes_decimal': None,
+         'array_fixed_decimal': None, 'union_uuid': None})
+    assert (data1_compare == data2)


### PR DESCRIPTION
Reordering results in invalid indexing being serialized. This fix instead special-cases handling of floats in `write_union`.

